### PR TITLE
test: set git config

### DIFF
--- a/src/tests/gitinfo_test.rs
+++ b/src/tests/gitinfo_test.rs
@@ -7,6 +7,9 @@ use crate::gitinfo;
 fn init_temp_repo() -> (tempfile::TempDir, git2::Repository) {
     let tmp_dir = tempfile::tempdir().unwrap();
     let repo = git2::Repository::init(tmp_dir.path()).unwrap();
+    let mut config = repo.config().unwrap();
+    config.set_str("user.name", "Test User").unwrap();
+    config.set_str("user.email", "test@example.com").unwrap();
     (tmp_dir, repo)
 }
 


### PR DESCRIPTION
Hi again,

Trying to run the tests in a nix sandbox, git2 does not read correctly the config:
```
git-statuses> failures:
git-statuses> ---- tests::gitinfo_test::test_get_repo_status_clean_dirty stdout ----
git-statuses> thread 'tests::gitinfo_test::test_get_repo_status_clean_dirty' panicked at src/tests/gitinfo_test.rs:63:32:
git-statuses> called `Result::unwrap()` on an `Err` value: Error { code: -3, klass: 7, message: "config value 'user.name' was not found" }
git-statuses> note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
git-statuses> ---- tests::gitinfo_test::test_get_branch_name_detached_head stdout ----
git-statuses> thread 'tests::gitinfo_test::test_get_branch_name_detached_head' panicked at src/tests/gitinfo_test.rs:104:32:
git-statuses> called `Result::unwrap()` on an `Err` value: Error { code: -3, klass: 7, message: "config value 'user.name' was not found" }
git-statuses> ---- tests::gitinfo_test::test_get_total_commits_multiple stdout ----
git-statuses> thread 'tests::gitinfo_test::test_get_total_commits_multiple' panicked at src/tests/gitinfo_test.rs:124:32:
git-statuses> called `Result::unwrap()` on an `Err` value: Error { code: -3, klass: 7, message: "config value 'user.name' was not found" }
git-statuses> ---- tests::gitinfo_test::test_get_changed_count stdout ----
git-statuses> thread 'tests::gitinfo_test::test_get_changed_count' panicked at src/tests/gitinfo_test.rs:45:32:
git-statuses> called `Result::unwrap()` on an `Err` value: Error { code: -3, klass: 7, message: "config value 'user.name' was not found" }
git-statuses> failures:
git-statuses>     tests::gitinfo_test::test_get_branch_name_detached_head
git-statuses>     tests::gitinfo_test::test_get_changed_count
git-statuses>     tests::gitinfo_test::test_get_repo_status_clean_dirty
git-statuses>     tests::gitinfo_test::test_get_total_commits_multiple
git-statuses> test result: FAILED. 15 passed; 4 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
```

Here is a fix for that: we should set the config in the temp repo, instead of relying on global/system/user config, to ensure they are more deterministic and portable.