### PR TITLE
feat: add the ability to use a condensed layout

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,6 +21,9 @@ pub struct Args {
     /// Show remote URL
     #[arg(short = 'r', long, action = ArgAction::SetTrue)]
     pub remote: bool,
+    /// Use a condensed layout
+    #[arg(short, long, action = ArgAction::SetTrue)]
+    pub condensed: bool,
     /// Show a summary of the scan
     #[arg(short, long, action = ArgAction::SetTrue)]
     pub summary: bool,

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -13,8 +13,13 @@ pub fn repositories_table(repos: &mut [RepoInfo], args: &Args) {
         return;
     }
     let mut table = Table::new();
+    let preset = if args.condensed {
+        presets::UTF8_FULL_CONDENSED
+    } else {
+        presets::UTF8_FULL
+    };
     table
-        .load_preset(presets::UTF8_FULL)
+        .load_preset(preset)
         .set_content_arrangement(ContentArrangement::Dynamic);
 
     let mut header = vec![


### PR DESCRIPTION
Hey there, great little tool!

I've added the ability to use a condensed layout which is more vertically efficient and allows you to see a lot more repos on one screen. Not sure if you prefer this to be the default behaviour but I made it a switch that you can opt into. 😄 

Cheers
Fotis