### PR TITLE
fix: display relative repo path instead of repo name in directory column

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -49,7 +49,10 @@ pub fn repositories_table(repos: &mut [RepoInfo], args: &Args) {
     table.set_header(header);
 
     for repo in repos_iter {
-        let name_cell = Cell::new(&repo.name).fg(repo.status.comfy_color());
+        let repo_path = repo.path.canonicalize().unwrap_or(repo.path.clone());
+        let root_path = args.dir.canonicalize().unwrap_or(args.dir.clone());
+        let repo_path_relative = repo_path.strip_prefix(&root_path).unwrap_or(&repo_path);
+        let name_cell = Cell::new(repo_path_relative.display().to_string()).fg(repo.status.comfy_color());
 
         let mut row = vec![
             name_cell,


### PR DESCRIPTION
Before:
```
git-statuses -c -d 2
┌─────────────┬─────────────────────┬────────────┬─────────┬─────────┐
│ Directory   ┆ Branch              ┆ Local      ┆ Commits ┆ Status  │
╞═════════════╪═════════════════════╪════════════╪═════════╪═════════╡
│ my-repo     ┆ master              ┆ ↑0 ↓0      ┆ 34      ┆ Clean   │
│ a           ┆ master (no commits) ┆ local-only ┆ 0       ┆ Unknown │
│ b           ┆ master (no commits) ┆ local-only ┆ 0       ┆ Unknown │
│ d           ┆ master (no commits) ┆ local-only ┆ 0       ┆ Unknown │
└─────────────┴─────────────────────┴────────────┴─────────┴─────────┘
```

After:

```
git-statuses -c -d 2
┌─────────────┬─────────────────────┬────────────┬─────────┬─────────┐
│ Directory   ┆ Branch              ┆ Local      ┆ Commits ┆ Status  │
╞═════════════╪═════════════════════╪════════════╪═════════╪═════════╡
│ foo/my-repo ┆ master              ┆ ↑0 ↓0      ┆ 34      ┆ Clean   │
│ a           ┆ master (no commits) ┆ local-only ┆ 0       ┆ Unknown │
│ b           ┆ master (no commits) ┆ local-only ┆ 0       ┆ Unknown │
│ c/d         ┆ master (no commits) ┆ local-only ┆ 0       ┆ Unknown │
└─────────────┴─────────────────────┴────────────┴─────────┴─────────┘
```

This fixes #35, #36 and probably #38.