### PR TITLE
ci: ship a native arm64 macOS binary

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,12 +49,13 @@ jobs:
   create-unix-binaries:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
           - os: macos-latest
             target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
The only macOS artifact was x86_64-apple-darwin, so Apple Silicon users relied on Rosetta 2 to run it. Machines without Rosetta installed fail with "bad CPU type in executable".

Add aarch64-apple-darwin to the release matrix so a native arm64 binary is published alongside the x86_64 one.

Dropping the top-level `os` key is required, not cosmetic: with it, both macos-latest include entries would merge into the same job and the last `target` would win, silently replacing the x86_64 build instead of adding the arm64 one. With include-only, each entry expands to its own job.

Closes #51