### PR TITLE
fix: consistency and correctness bugs across scanning, status and output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,4 +120,4 @@ jobs:
         uses: taiki-e/install-action@cargo-tarpaulin
 
       - name: Run coverage check
-        run: cargo tarpaulin --workspace --all-features --fail-under 90 --out Xml --out Stdout
+        run: cargo tarpaulin --workspace --all-features --fail-under 95 --out Xml --out Stdout

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Arguments:
   [DIR]  Directory to scan [default: .]
 
 Options:
-  -d, --depth <DEPTH>        Recursively scan all subdirectories to the given depth. If set to 1, only the current directory is scanned. If set to -1, all subdirectories are scanned. (this may take a while) [default: 1]
+  -d, --depth <DEPTH>        Recursively scan all subdirectories to the given depth. If set to 1, only the current directory is scanned. If set to a negative value, all subdirectories are scanned. (this may take a while) [default: 1]
   -r, --remote               Show remote URL
   -c, --condensed            Use a condensed layout
   -s, --summary              Show a summary of the scan

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, path::PathBuf, sync::Arc};
+use std::{borrow::Cow, ffi::OsStr, path::PathBuf, sync::Arc};
 
 use clap::Parser;
 use clap_complete::Shell;
@@ -91,7 +91,14 @@ impl Args {
                 walk = walk.max_depth(self.depth.max(1) as usize);
             }
 
-            walk.into_iter().filter_map(Result::ok).collect::<Vec<_>>()
+            // Never descend into a repository's own git directory. Nothing inside it is a
+            // repository the user asked about - it holds git's bookkeeping, including the
+            // `worktrees/<name>` metadata directories - and on a deep scan it is a lot of
+            // entries to walk and stat for nothing.
+            walk.into_iter()
+                .filter_entry(|e| e.depth() == 0 || e.file_name() != OsStr::new(".git"))
+                .filter_map(Result::ok)
+                .collect::<Vec<_>>()
         };
 
         let repos: Arc<RwLock<Vec<RepoInfo>>> = Arc::new(RwLock::new(Vec::new()));
@@ -99,12 +106,6 @@ impl Args {
 
         walker.par_iter().for_each(|entry| {
             let orig_path = entry.path();
-
-            // Skip internal .git/worktrees directories - these are metadata, not actual repos
-            if orig_path.to_string_lossy().contains("/.git/worktrees/") {
-                return;
-            }
-
             let repo_name = orig_path.dir_name();
             let path_buf = {
                 if orig_path.is_git_directory() || orig_path.is_git_worktree() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -66,6 +66,10 @@ pub struct Args {
 impl Args {
     /// Scans the given directory (recursively if requested) for Git repositories and collects their status information.
     ///
+    /// The repositories are collected in parallel, so both returned vectors are sorted
+    /// before they are handed back. Every consumer (table, JSON, warnings) therefore sees
+    /// the same, reproducible order.
+    ///
     /// # Returns
     /// A tuple containing:
     /// - A vector of `RepoInfo` containing details about each found repository.
@@ -138,6 +142,11 @@ impl Args {
                 }
             }
         });
-        (repos.read().to_vec(), failed_repos.read().to_vec())
+
+        let mut repos = repos.read().to_vec();
+        let mut failed_repos = failed_repos.read().to_vec();
+        repos.sort_by_key(|r| r.repo_path.to_lowercase());
+        failed_repos.sort_by_key(|r| r.to_lowercase());
+        (repos, failed_repos)
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,8 +25,8 @@ pub struct Args {
     pub dir: PathBuf,
     /// Recursively scan all subdirectories to the given depth.
     /// If set to 1, only the current directory is scanned.
-    /// If set to -1, all subdirectories are scanned. (this may take a while)
-    #[arg(short, long, default_value = "1")]
+    /// If set to a negative value, all subdirectories are scanned. (this may take a while)
+    #[arg(short, long, default_value = "1", allow_negative_numbers = true)]
     pub depth: i32,
     /// Show remote URL
     #[arg(short = 'r', long)]
@@ -82,15 +82,13 @@ impl Args {
         reason = "We check i32 to be non-negative, so casting to usize is safe"
     )]
     pub fn find_repositories(&self) -> (Vec<RepoInfo>, Vec<String>) {
-        let min_depth = 0;
         let walker = {
-            let mut walk = WalkDir::new(&self.dir)
-                .min_depth(min_depth)
-                .follow_links(false);
+            let mut walk = WalkDir::new(&self.dir).min_depth(0).follow_links(false);
 
-            if self.depth != -1 && self.depth >= 0 {
-                let max_depth = if self.depth > 0 { self.depth } else { 1 };
-                walk = walk.max_depth(max_depth as usize);
+            // Any negative depth means "no limit"; `-1` is just the documented spelling.
+            // A depth of 0 would find nothing at all, so it is treated like 1.
+            if self.depth >= 0 {
+                walk = walk.max_depth(self.depth.max(1) as usize);
             }
 
             walk.into_iter().filter_map(Result::ok).collect::<Vec<_>>()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, sync::Arc};
+use std::{borrow::Cow, path::PathBuf, sync::Arc};
 
 use clap::Parser;
 use clap_complete::Shell;
@@ -6,7 +6,10 @@ use parking_lot::RwLock;
 use rayon::iter::{IntoParallelRefIterator as _, ParallelIterator as _};
 use walkdir::WalkDir;
 
-use crate::{gitinfo::repoinfo::RepoInfo, util::GitPathExt as _};
+use crate::{
+    gitinfo::{repoinfo::RepoInfo, status::Status},
+    util::GitPathExt as _,
+};
 
 /// Scan the given directory for Git repositories and display their status.
 /// A Repository turns red if it has unpushed changes.
@@ -148,5 +151,26 @@ impl Args {
         repos.sort_by_key(|r| r.repo_path.to_lowercase());
         failed_repos.sort_by_key(|r| r.to_lowercase());
         (repos, failed_repos)
+    }
+
+    /// Applies the output filters (currently only `--non-clean`) to a scan result.
+    ///
+    /// Every output format has to go through this, otherwise the formats disagree about
+    /// which repositories the user asked to see.
+    ///
+    /// # Returns
+    /// The repositories to display. Borrows the input when no filter is active.
+    pub fn filter_repos<'a>(&self, repos: &'a [RepoInfo]) -> Cow<'a, [RepoInfo]> {
+        if self.non_clean {
+            Cow::Owned(
+                repos
+                    .iter()
+                    .filter(|r| r.status != Status::Clean)
+                    .cloned()
+                    .collect(),
+            )
+        } else {
+            Cow::Borrowed(repos)
+        }
     }
 }

--- a/src/gitinfo/mod.rs
+++ b/src/gitinfo/mod.rs
@@ -10,6 +10,23 @@ use crate::gitinfo::status::Status;
 pub mod repoinfo;
 pub mod status;
 
+/// The status bits that make a working directory count as changed.
+///
+/// Shared by the clean/dirty decision and by the change counter shown next to it, so the
+/// two can never disagree about what a change is. `TYPECHANGE` matters for files that were
+/// swapped for a symlink (or vice versa), `RENAMED` for renames once git detects them.
+pub const CHANGED: git2::Status = git2::Status::WT_NEW
+    .union(git2::Status::WT_MODIFIED)
+    .union(git2::Status::WT_DELETED)
+    .union(git2::Status::WT_TYPECHANGE)
+    .union(git2::Status::WT_RENAMED)
+    .union(git2::Status::INDEX_NEW)
+    .union(git2::Status::INDEX_MODIFIED)
+    .union(git2::Status::INDEX_DELETED)
+    .union(git2::Status::INDEX_TYPECHANGE)
+    .union(git2::Status::INDEX_RENAMED)
+    .union(git2::Status::CONFLICTED);
+
 /// Gets the first available remote name, preferring "origin".
 /// If "origin" doesn't exist, it returns the first available remote.
 /// # Arguments
@@ -164,20 +181,11 @@ pub fn get_total_commits(repo: &Repository) -> anyhow::Result<usize> {
 /// Returns the number of changed (unstaged, staged or untracked) files.
 pub fn get_changed_count(repo: &Repository) -> usize {
     let mut opts = StatusOptions::new();
-    opts.include_untracked(true);
+    opts.include_untracked(true).include_ignored(false);
     repo.statuses(Some(&mut opts)).map_or(0, |statuses| {
         statuses
             .iter()
-            .filter(|e| {
-                let s = e.status();
-                s.is_wt_modified()
-                    || s.is_index_modified()
-                    || s.is_wt_deleted()
-                    || s.is_index_deleted()
-                    || s.is_conflicted()
-                    || s.is_wt_new()
-                    || s.is_index_new()
-            })
+            .filter(|e| !e.status().is_ignored() && e.status().intersects(CHANGED))
             .count()
     })
 }

--- a/src/gitinfo/mod.rs
+++ b/src/gitinfo/mod.rs
@@ -50,6 +50,28 @@ fn get_repo_path(repo: &Repository) -> path::PathBuf {
     }
 }
 
+/// Extracts the repository name from a remote URL.
+///
+/// Handles the shapes git accepts: `https://host/user/repo.git`, the SCP-like
+/// `git@host:user/repo.git` (and its slash-less `git@host:repo.git` form), local paths,
+/// and any of those with a trailing slash.
+///
+/// # Arguments
+/// * `url` - The remote URL to parse.
+/// # Returns
+/// The repository name, or `None` if the URL carries no usable name.
+pub fn repo_name_from_url(url: &str) -> Option<String> {
+    // A trailing slash would otherwise make the last segment empty.
+    let url = url.trim_end_matches('/');
+    // Both separators matter: in `git@host:repo.git` the name is not preceded by a slash.
+    let name = url.rsplit(['/', ':', '\\']).next()?;
+    // `strip_suffix` rather than `trim_end_matches`, which would strip a repeated suffix
+    // and turn `repo.git.git` into `repo`.
+    let name = name.strip_suffix(".git").unwrap_or(name);
+
+    (!name.is_empty()).then(|| name.to_owned())
+}
+
 /// Gets the name of the repository from the remote URL.
 /// If the remote URL is not available, it returns `None`.
 /// # Arguments
@@ -58,19 +80,10 @@ fn get_repo_path(repo: &Repository) -> path::PathBuf {
 /// An `Option<String>` containing the repository name if found, or `None` if not.
 fn get_repo_name(repo: &Repository) -> Option<String> {
     let remote_name = get_remote_name(repo)?;
-    if let Ok(remote) = repo.find_remote(&remote_name)
-        && let Ok(url) = remote.url()
-    {
-        return Some(
-            url.trim_end_matches(".git")
-                .split('/')
-                .next_back()
-                .unwrap_or("unknown")
-                .to_owned(),
-        );
-    }
+    let remote = repo.find_remote(&remote_name).ok()?;
+    let url = remote.url().ok()?;
 
-    None
+    repo_name_from_url(url)
 }
 
 /// Returns the current branch name or a fallback if not available.

--- a/src/gitinfo/mod.rs
+++ b/src/gitinfo/mod.rs
@@ -180,10 +180,13 @@ pub fn get_remote_url(repo: &Repository) -> Option<String> {
 /// Executes a fetch operation for the first available remote (preferring "origin") to update upstream information.
 pub fn fetch_origin(repo: &Repository) -> anyhow::Result<()> {
     let remote_name = get_remote_name(repo).ok_or_else(|| anyhow::anyhow!("No remotes found"))?;
+    // `repo.path()` is the git directory. For a worktree that is
+    // `<main>/.git/worktrees/<name>`, whose parent is not a working directory at all, so
+    // prefer the working directory and only fall back for bare repositories.
     let path = repo
-        .path()
-        .parent()
-        .ok_or_else(|| anyhow::anyhow!("No parent directory found"))?;
+        .workdir()
+        .or_else(|| repo.path().parent())
+        .ok_or_else(|| anyhow::anyhow!("No working directory found"))?;
     let output = Command::new("git")
         .arg("fetch")
         .arg(&remote_name)

--- a/src/gitinfo/repoinfo.rs
+++ b/src/gitinfo/repoinfo.rs
@@ -2,7 +2,10 @@ use std::path::{Path, PathBuf};
 
 use git2::Repository;
 
-use crate::gitinfo::{self, status::Status};
+use crate::{
+    gitinfo::{self, status::Status},
+    util::GitPathExt as _,
+};
 
 /// Holds information about a Git repository for status display.
 #[expect(
@@ -96,13 +99,15 @@ impl RepoInfo {
         let repo_path = path.canonicalize().unwrap_or_else(|_| path.clone());
         let root_path = dir.canonicalize().unwrap_or_else(|_| dir.to_path_buf());
         let repo_path_relative = repo_path.strip_prefix(&root_path).unwrap_or(&repo_path);
-        // if relative path is empty, use repo_path
-        let repo_path_relative = if repo_path_relative.as_os_str().is_empty() {
-            &repo_path
+        // The scanned directory is the repository itself when git-statuses is run from
+        // inside one, which leaves the relative path empty. Fall back to the directory
+        // name, so the column reads like it would for a repository one level down instead
+        // of suddenly showing an absolute path.
+        let repo_path = if repo_path_relative.as_os_str().is_empty() {
+            repo_path.dir_name()
         } else {
-            repo_path_relative
+            repo_path_relative.display().to_string()
         };
-        let repo_path = repo_path_relative.display().to_string();
         let is_worktree = repo.is_worktree();
 
         Ok(Self {

--- a/src/gitinfo/repoinfo.rs
+++ b/src/gitinfo/repoinfo.rs
@@ -53,10 +53,10 @@ impl RepoInfo {
     /// A `RepoInfo` instance containing the repository's status information.
     ///
     /// # Errors
-    /// Returns an error if the repository cannot be opened, or if fetching fails.
-    /// If `fetch` is true, it will attempt to fetch from the "origin"
-    /// remote to update upstream information.
-    /// If fetching fails, it will use that error to return an error.
+    /// Returns an error if the commit history of the repository cannot be walked.
+    ///
+    /// Fetching and fast-forwarding are best-effort: a repository without a remote
+    /// or without an upstream branch is still reported, with a warning logged.
     pub fn new(
         repo: &mut Repository,
         name: &str,
@@ -65,11 +65,22 @@ impl RepoInfo {
         merge: bool,
         dir: &Path,
     ) -> anyhow::Result<Self> {
-        if fetch || merge {
-            // Attempt to fetch from origin, ignoring errors
-            gitinfo::fetch_origin(repo)?;
-        }
         let name = gitinfo::get_repo_name(repo).unwrap_or_else(|| name.to_owned());
+
+        // Fetching and merging must happen before any state is gathered, otherwise the
+        // reported ahead/behind counts, commit count and status describe the pre-merge
+        // repository and contradict the fast-forward marker shown next to them.
+        if (fetch || merge)
+            && let Err(e) = gitinfo::fetch_origin(repo)
+        {
+            log::warn!("Failed to fetch for `{name}`: {e}");
+        }
+        let fast_forwarded = merge
+            && gitinfo::merge_ff(repo).unwrap_or_else(|e| {
+                log::warn!("Failed to fast-forward `{name}`: {e}");
+                false
+            });
+
         let branch = gitinfo::get_branch_name(repo);
         let (ahead, behind, is_local_only) = gitinfo::get_ahead_behind_and_local_status(repo);
         let commits = gitinfo::get_total_commits(repo)?;
@@ -91,12 +102,7 @@ impl RepoInfo {
         } else {
             repo_path_relative
         };
-        let fast_forwarded = if merge {
-            // Fast-forward merge
-            gitinfo::merge_ff(repo)?
-        } else {
-            false
-        };
+        let repo_path = repo_path_relative.display().to_string();
         let is_worktree = repo.is_worktree();
 
         Ok(Self {
@@ -112,7 +118,7 @@ impl RepoInfo {
             stash_count,
             is_local_only,
             fast_forwarded,
-            repo_path: repo_path_relative.display().to_string(),
+            repo_path,
             is_worktree,
         })
     }

--- a/src/gitinfo/status.rs
+++ b/src/gitinfo/status.rs
@@ -66,23 +66,15 @@ impl Status {
 
         repo.statuses(Some(&mut opts))
             .map_or(Self::Unknown, |statuses| {
-                if statuses.iter().all(|e| {
-                    e.status().is_ignored()
-                        || !e.status().intersects(
-                            git2::Status::WT_NEW
-                                | git2::Status::WT_MODIFIED
-                                | git2::Status::WT_DELETED
-                                | git2::Status::INDEX_NEW
-                                | git2::Status::INDEX_MODIFIED
-                                | git2::Status::INDEX_DELETED
-                                | git2::Status::CONFLICTED,
-                        )
-                }) {
-                    // Clean working directory – check branch push state
-                    gitinfo::get_branch_push_status(repo)
-                } else {
+                if statuses
+                    .iter()
+                    .any(|e| !e.status().is_ignored() && e.status().intersects(gitinfo::CHANGED))
+                {
                     // Dirty working directory – report how many changes
                     Self::Dirty(gitinfo::get_changed_count(repo))
+                } else {
+                    // Clean working directory – check branch push state
+                    gitinfo::get_branch_push_status(repo)
                 }
             })
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,8 @@
-use std::io;
+use std::io::{self, Write};
 
 use anyhow::Result;
 use clap::{CommandFactory as _, Parser as _};
+use clap_complete::Shell;
 
 use crate::cli::Args;
 
@@ -17,17 +18,29 @@ mod util;
 fn main() -> Result<()> {
     util::initialize_logger()?;
 
-    let args = Args::parse();
+    run(&Args::parse(), &mut io::stdout());
 
+    Ok(())
+}
+
+/// Runs the tool for the given arguments.
+///
+/// Split out of `main` so that it can be driven from tests without spawning a process.
+/// Repositories that cannot be read are collected into the failed list rather than
+/// aborting the scan, so this cannot fail.
+///
+/// # Arguments
+/// * `args` - The parsed CLI arguments.
+/// * `out` - Where to write generated shell completions to.
+fn run(args: &Args, out: &mut impl Write) {
     if let Some(shell) = args.completions {
-        let mut cmd = Args::command();
-        clap_complete::generate(shell, &mut cmd, env!("CARGO_PKG_NAME"), &mut io::stdout());
-        return Ok(());
+        completions(shell, out);
+        return;
     }
 
     if args.legend {
         printer::legend(args.condensed);
-        return Ok(());
+        return;
     }
 
     let (repos, failed_repos) = args.find_repositories();
@@ -35,15 +48,27 @@ fn main() -> Result<()> {
 
     if args.json {
         printer::json_output(&displayed, &failed_repos);
-        return Ok(());
+        return;
     }
 
-    printer::repositories_table(&displayed, &args);
+    printer::repositories_table(&displayed, args);
     printer::failed_summary(&failed_repos);
     if args.summary {
         // The summary describes the whole scan, not just the filtered selection.
         printer::summary(&repos, failed_repos.len());
     }
+}
 
-    Ok(())
+/// Writes the shell completion script for `shell`.
+///
+/// # Arguments
+/// * `shell` - The shell to generate completions for.
+/// * `out` - Where to write the completion script to.
+fn completions(shell: Shell, out: &mut impl Write) {
+    clap_complete::generate(
+        shell,
+        &mut Args::command(),
+        env!("CARGO_PKG_NAME"),
+        &mut *out,
+    );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,15 +31,17 @@ fn main() -> Result<()> {
     }
 
     let (repos, failed_repos) = args.find_repositories();
+    let displayed = args.filter_repos(&repos);
 
     if args.json {
-        printer::json_output(&repos, &failed_repos);
+        printer::json_output(&displayed, &failed_repos);
         return Ok(());
     }
 
-    printer::repositories_table(&repos, &args);
+    printer::repositories_table(&displayed, &args);
     printer::failed_summary(&failed_repos);
     if args.summary {
+        // The summary describes the whole scan, not just the filtered selection.
         printer::summary(&repos, failed_repos.len());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,14 +30,14 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    let (mut repos, failed_repos) = args.find_repositories();
+    let (repos, failed_repos) = args.find_repositories();
 
     if args.json {
         printer::json_output(&repos, &failed_repos);
         return Ok(());
     }
 
-    printer::repositories_table(&mut repos, &args);
+    printer::repositories_table(&repos, &args);
     printer::failed_summary(&failed_repos);
     if args.summary {
         printer::summary(&repos, failed_repos.len());

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -8,6 +8,9 @@ use crate::{
 
 /// Prints the repository status information as a table or list, depending on CLI options.
 ///
+/// Expects the repositories to already be sorted and filtered (see
+/// `Args::find_repositories` and `Args::filter_repos`).
+///
 /// # Arguments
 /// * `repos` - List of repositories to display.
 /// * `args` - CLI arguments controlling the output format.
@@ -16,11 +19,6 @@ pub fn repositories_table(repos: &[RepoInfo], args: &Args) {
         log::info!("No repositories found.");
         return;
     }
-    let repos_iter: Box<dyn Iterator<Item = &RepoInfo>> = if args.non_clean {
-        Box::new(repos.iter().filter(|r| r.status != Status::Clean))
-    } else {
-        Box::new(repos.iter())
-    };
 
     let mut table = Table::new();
     let preset = if args.condensed {
@@ -47,7 +45,7 @@ pub fn repositories_table(repos: &[RepoInfo], args: &Args) {
     }
     table.set_header(header);
 
-    for repo in repos_iter {
+    for repo in repos {
         let display_path = if repo.is_worktree {
             format!("⎇ {}", repo.repo_path)
         } else {
@@ -141,14 +139,23 @@ pub fn failed_summary(failed_repos: &[String]) {
     }
 }
 
+/// Builds the JSON representation of a scan result.
+/// # Arguments
+/// * `repos` - List of repositories to output.
+/// * `failed_repos` - List of repository names that failed to process.
+/// # Returns
+/// The JSON value that `json_output` prints.
+pub fn json_value(repos: &[RepoInfo], failed_repos: &[String]) -> serde_json::Value {
+    serde_json::json!({
+        "repositories": repos,
+        "failed": failed_repos
+    })
+}
+
 /// Prints the repository information in JSON format.
 /// # Arguments
 /// * `repos` - List of repositories to output.
 /// * `failed_repos` - List of repository names that failed to process.
 pub fn json_output(repos: &[RepoInfo], failed_repos: &[String]) {
-    let output = serde_json::json!({
-        "repositories": repos,
-        "failed": failed_repos
-    });
-    println!("{output}");
+    println!("{}", json_value(repos, failed_repos));
 }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -11,12 +11,11 @@ use crate::{
 /// # Arguments
 /// * `repos` - List of repositories to display.
 /// * `args` - CLI arguments controlling the output format.
-pub fn repositories_table(repos: &mut [RepoInfo], args: &Args) {
+pub fn repositories_table(repos: &[RepoInfo], args: &Args) {
     if repos.is_empty() {
         log::info!("No repositories found.");
         return;
     }
-    repos.sort_by_key(|r| r.repo_path.to_ascii_lowercase());
     let repos_iter: Box<dyn Iterator<Item = &RepoInfo>> = if args.non_clean {
         Box::new(repos.iter().filter(|r| r.status != Status::Clean))
     } else {

--- a/src/tests/gitinfo_test.rs
+++ b/src/tests/gitinfo_test.rs
@@ -737,3 +737,135 @@ fn test_ignored_files_do_not_make_a_repository_dirty() {
         "an ignored file is not a change"
     );
 }
+
+/// Commits an initial commit so the repository has a HEAD to reason about.
+fn commit_initial(tmp: &tempfile::TempDir, repo: &Repository) {
+    fs::write(tmp.path().join("file.txt"), "content").unwrap();
+    let mut index = repo.index().unwrap();
+    index.add_path(Path::new("file.txt")).unwrap();
+    index.write().unwrap();
+    let oid = index.write_tree().unwrap();
+    let sig = repo.signature().unwrap();
+    let tree = repo.find_tree(oid).unwrap();
+    repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+        .unwrap();
+}
+
+/// git records an in-progress operation with marker files inside the git directory, and
+/// each one maps to a distinct status. These are the states a user most wants to be warned
+/// about, so every arm must map to the status it claims.
+#[test]
+fn test_status_reflects_in_progress_git_operations() {
+    // (marker to create, is it a directory, expected status)
+    let cases: &[(&str, bool, Status)] = &[
+        ("MERGE_HEAD", false, Status::Merge),
+        ("REVERT_HEAD", false, Status::Revert),
+        ("CHERRY_PICK_HEAD", false, Status::CherryPick),
+        ("BISECT_LOG", false, Status::Bisect),
+        ("rebase-merge", true, Status::Rebase),
+        ("rebase-merge/interactive", false, Status::Rebase),
+        ("rebase-apply/rebasing", false, Status::Rebase),
+        // An in-progress `git am` is not something this tool can classify further.
+        ("rebase-apply/applying", false, Status::Unknown),
+        ("rebase-apply", true, Status::Unknown),
+    ];
+
+    for (marker, is_dir, expected) in cases {
+        let (tmp, repo) = init_temp_repo();
+        commit_initial(&tmp, &repo);
+        assert_ne!(
+            Status::new(&repo),
+            *expected,
+            "`{marker}` must not already be the status before the marker exists"
+        );
+
+        let path = tmp.path().join(".git").join(marker);
+        if *is_dir {
+            fs::create_dir_all(&path).unwrap();
+        } else {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).unwrap();
+            }
+            fs::write(&path, "1234567890abcdef1234567890abcdef12345678\n").unwrap();
+        }
+
+        assert_eq!(
+            Status::new(&repo),
+            *expected,
+            "`{marker}` must be reported as {expected}"
+        );
+    }
+}
+
+/// A sequencer todo file turns a revert or cherry-pick into its *Sequence* variant, which
+/// must still be reported as the same user-visible status.
+#[test]
+fn test_status_reflects_sequencer_operations() {
+    for (marker, expected) in [
+        ("REVERT_HEAD", Status::Revert),
+        ("CHERRY_PICK_HEAD", Status::CherryPick),
+    ] {
+        let (tmp, repo) = init_temp_repo();
+        commit_initial(&tmp, &repo);
+
+        let git_dir = tmp.path().join(".git");
+        fs::write(
+            git_dir.join(marker),
+            "1234567890abcdef1234567890abcdef12345678\n",
+        )
+        .unwrap();
+        fs::create_dir_all(git_dir.join("sequencer")).unwrap();
+        fs::write(git_dir.join("sequencer/todo"), "pick 1234567\n").unwrap();
+
+        assert_eq!(
+            Status::new(&repo),
+            expected,
+            "a sequenced `{marker}` must be reported as {expected}"
+        );
+    }
+}
+
+/// The path reported for a bare repository, which has no working directory to fall back to.
+#[test]
+fn test_get_repo_path_for_bare_repository() {
+    let tmp = tempfile::tempdir().unwrap();
+    let bare_path = tmp.path().join("bare.git");
+    let repo = Repository::init_bare(&bare_path).unwrap();
+
+    assert!(repo.workdir().is_none(), "a bare repo has no working dir");
+    let info = RepoInfo::new(
+        &mut Repository::open(&bare_path).unwrap(),
+        "bare",
+        false,
+        false,
+        false,
+        tmp.path(),
+    )
+    .unwrap();
+
+    // `Path::ends_with` compares whole components, so the `.git` suffix that is stripped
+    // from a normal repository's git directory must not eat the `bare.git` name here.
+    assert_eq!(
+        info.path.canonicalize().unwrap(),
+        bare_path.canonicalize().unwrap()
+    );
+    assert_eq!(info.repo_path, "bare.git");
+}
+
+/// A bare repository does not have to be named `<name>.git`. Its git directory then has no
+/// `.git` suffix to strip and is used as-is.
+#[test]
+fn test_get_repo_path_for_bare_repository_without_git_suffix() {
+    let tmp = tempfile::tempdir().unwrap();
+    let bare_path = tmp.path().join("plain-bare");
+    Repository::init_bare(&bare_path).unwrap();
+
+    let mut repo = Repository::open(&bare_path).unwrap();
+    let info = RepoInfo::new(&mut repo, "plain-bare", false, false, false, tmp.path()).unwrap();
+
+    assert_eq!(
+        info.path.canonicalize().unwrap(),
+        bare_path.canonicalize().unwrap()
+    );
+    assert_eq!(info.repo_path, "plain-bare");
+}

--- a/src/tests/gitinfo_test.rs
+++ b/src/tests/gitinfo_test.rs
@@ -528,3 +528,113 @@ fn test_get_branch_push_status_no_remote() {
     let status = gitinfo::get_branch_push_status(&repo);
     assert_eq!(status, Status::Unpublished);
 }
+
+#[test]
+fn test_repo_name_from_url_https() {
+    assert_eq!(
+        gitinfo::repo_name_from_url("https://github.com/user/repo.git").as_deref(),
+        Some("repo")
+    );
+    assert_eq!(
+        gitinfo::repo_name_from_url("https://github.com/user/repo").as_deref(),
+        Some("repo")
+    );
+}
+
+/// The SCP-like syntax separates the path with a colon. Splitting on `/` alone left the
+/// whole `git@host:repo` string as the repository name when the path had no slash in it.
+#[test]
+fn test_repo_name_from_url_scp_syntax() {
+    assert_eq!(
+        gitinfo::repo_name_from_url("git@github.com:user/repo.git").as_deref(),
+        Some("repo")
+    );
+    assert_eq!(
+        gitinfo::repo_name_from_url("git@github.com:repo.git").as_deref(),
+        Some("repo")
+    );
+}
+
+/// A trailing slash made the last path segment empty, which surfaced as a nameless
+/// repository in the output.
+#[test]
+fn test_repo_name_from_url_trailing_slash() {
+    assert_eq!(
+        gitinfo::repo_name_from_url("https://github.com/user/repo/").as_deref(),
+        Some("repo")
+    );
+    assert_eq!(
+        gitinfo::repo_name_from_url("https://github.com/user/repo.git/").as_deref(),
+        Some("repo")
+    );
+}
+
+/// `trim_end_matches(".git")` strips *every* trailing occurrence, so a repository actually
+/// called `repo.git` lost part of its name.
+#[test]
+fn test_repo_name_from_url_only_strips_one_git_suffix() {
+    assert_eq!(
+        gitinfo::repo_name_from_url("https://github.com/user/repo.git.git").as_deref(),
+        Some("repo.git")
+    );
+}
+
+#[test]
+fn test_repo_name_from_url_local_path() {
+    assert_eq!(
+        gitinfo::repo_name_from_url("/home/user/projects/repo").as_deref(),
+        Some("repo")
+    );
+    assert_eq!(
+        gitinfo::repo_name_from_url("C:\\projects\\repo.git").as_deref(),
+        Some("repo")
+    );
+}
+
+#[test]
+fn test_repo_name_from_url_without_a_name() {
+    assert_eq!(gitinfo::repo_name_from_url(""), None);
+    assert_eq!(gitinfo::repo_name_from_url("/"), None);
+    assert_eq!(gitinfo::repo_name_from_url(".git"), None);
+}
+
+/// The name shown for a repository comes from its remote. It must survive the round trip
+/// through `git2` for the URL shapes git actually accepts.
+#[test]
+fn test_repo_info_name_from_scp_style_remote() {
+    let (_tmp, mut repo) = init_temp_repo();
+    repo.remote("origin", "git@github.com:bircni/git-statuses.git")
+        .unwrap();
+
+    let info = RepoInfo::new(
+        &mut repo,
+        "fallback-name",
+        false,
+        false,
+        false,
+        &PathBuf::from("/path/to/repo"),
+    )
+    .unwrap();
+
+    assert_eq!(info.name, "git-statuses");
+}
+
+/// A remote whose URL yields no usable name must fall back to the directory name instead
+/// of showing an empty or bogus one.
+#[test]
+fn test_repo_info_name_falls_back_to_directory_name() {
+    let (_tmp, mut repo) = init_temp_repo();
+    repo.remote("origin", "/").unwrap();
+
+    let info = RepoInfo::new(
+        &mut repo,
+        "fallback-name",
+        false,
+        false,
+        false,
+        &PathBuf::from("/path/to/repo"),
+    )
+    .unwrap();
+
+    assert_eq!(info.name, "fallback-name");
+}

--- a/src/tests/gitinfo_test.rs
+++ b/src/tests/gitinfo_test.rs
@@ -638,3 +638,102 @@ fn test_repo_info_name_falls_back_to_directory_name() {
 
     assert_eq!(info.name, "fallback-name");
 }
+
+/// Replacing a tracked file with a symlink is a `TYPECHANGE`. `git status` reports it as a
+/// modification, but neither the clean/dirty check nor the change counter looked at that
+/// bit, so such a repository was reported as Clean with zero changes.
+#[cfg(unix)]
+#[test]
+fn test_typechange_is_reported_as_dirty() {
+    let (tmp, repo) = init_temp_repo();
+    let path = tmp.path().join("file.txt");
+    fs::write(&path, "content").unwrap();
+    let mut index = repo.index().unwrap();
+    index.add_path(Path::new("file.txt")).unwrap();
+    index.write().unwrap();
+    let oid = index.write_tree().unwrap();
+    let sig = repo.signature().unwrap();
+    let tree = repo.find_tree(oid).unwrap();
+    repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+        .unwrap();
+    drop(tree);
+    drop(index);
+
+    // Replace the regular file with a symlink pointing elsewhere.
+    fs::remove_file(&path).unwrap();
+    std::os::unix::fs::symlink("/etc/hostname", &path).unwrap();
+
+    assert_eq!(
+        gitinfo::get_changed_count(&repo),
+        1,
+        "a typechange is a change"
+    );
+    assert_eq!(
+        Status::new(&repo),
+        Status::Dirty(1),
+        "a repository with a typechange is not clean"
+    );
+}
+
+/// The clean/dirty decision and the count displayed next to it are two separate scans of
+/// the same working directory. They must agree: a repository reported as Dirty(n) must have
+/// n changed files, and one reported as anything else must have none.
+#[test]
+fn test_status_and_changed_count_agree() {
+    let (tmp, repo) = init_temp_repo();
+    let path = tmp.path().join("file.txt");
+    fs::write(&path, "content").unwrap();
+    let mut index = repo.index().unwrap();
+    index.add_path(Path::new("file.txt")).unwrap();
+    index.write().unwrap();
+    let oid = index.write_tree().unwrap();
+    let sig = repo.signature().unwrap();
+    let tree = repo.find_tree(oid).unwrap();
+    repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+        .unwrap();
+    drop(tree);
+    drop(index);
+
+    // A committed working directory has no changes at all.
+    assert_eq!(gitinfo::get_changed_count(&repo), 0);
+    assert_ne!(Status::new(&repo), Status::Dirty(0));
+
+    // Each new kind of change must move both the status and the count in lockstep.
+    fs::write(tmp.path().join("untracked.txt"), "new").unwrap();
+    assert_eq!(Status::new(&repo), Status::Dirty(1));
+
+    fs::write(&path, "modified").unwrap();
+    assert_eq!(Status::new(&repo), Status::Dirty(2));
+
+    assert_eq!(
+        Status::new(&repo),
+        Status::Dirty(gitinfo::get_changed_count(&repo)),
+        "the reported count must be the same one the dirty check used"
+    );
+}
+
+/// Ignored files are not changes and must not make a repository dirty.
+#[test]
+fn test_ignored_files_do_not_make_a_repository_dirty() {
+    let (tmp, repo) = init_temp_repo();
+    fs::write(tmp.path().join(".gitignore"), "ignored.txt\n").unwrap();
+    let mut index = repo.index().unwrap();
+    index.add_path(Path::new(".gitignore")).unwrap();
+    index.write().unwrap();
+    let oid = index.write_tree().unwrap();
+    let sig = repo.signature().unwrap();
+    let tree = repo.find_tree(oid).unwrap();
+    repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+        .unwrap();
+    drop(tree);
+    drop(index);
+
+    fs::write(tmp.path().join("ignored.txt"), "please ignore me").unwrap();
+
+    assert_eq!(gitinfo::get_changed_count(&repo), 0);
+    assert_ne!(
+        Status::new(&repo),
+        Status::Dirty(0),
+        "an ignored file is not a change"
+    );
+}

--- a/src/tests/integration_test.rs
+++ b/src/tests/integration_test.rs
@@ -636,3 +636,43 @@ fn test_integration_worktree_with_changes() {
         worktree.status
     );
 }
+
+/// Scanning a repository directly (the common `git-statuses` with no argument, run from
+/// inside a checkout) leaves the path relative to the scan root empty. It used to fall back
+/// to the absolute path, so the Directory column showed `/home/user/code/my-repo` here but
+/// a bare `my-repo` for the very same repository when scanning its parent.
+#[test]
+fn test_integration_scanning_a_repository_directly_shows_its_name() {
+    let temp_dir = TempDir::new().unwrap();
+    let _repo = create_git_repo_with_commit(temp_dir.path(), "my-repo");
+    let repo_dir = temp_dir.path().join("my-repo");
+
+    let scanned_directly = Args {
+        dir: repo_dir.clone(),
+        depth: 1,
+        ..Default::default()
+    };
+    let (repos, failed) = scanned_directly.find_repositories();
+
+    assert_eq!(failed.len(), 0);
+    assert_eq!(repos.len(), 1);
+    assert_eq!(
+        repos[0].repo_path, "my-repo",
+        "a directly scanned repository must be shown by name, not by absolute path"
+    );
+
+    // Scanning the parent must produce the same label for the same repository.
+    let scanned_from_parent = Args {
+        dir: temp_dir.path().to_path_buf(),
+        depth: 1,
+        ..Default::default()
+    };
+    let (from_parent, _) = scanned_from_parent.find_repositories();
+    assert_eq!(from_parent[0].repo_path, repos[0].repo_path);
+
+    // The absolute location is still available in the dedicated path field (`--path`).
+    assert_eq!(
+        repos[0].path.canonicalize().unwrap(),
+        repo_dir.canonicalize().unwrap()
+    );
+}

--- a/src/tests/integration_test.rs
+++ b/src/tests/integration_test.rs
@@ -721,3 +721,52 @@ fn test_integration_depth_edge_values() {
         "i32::MIN must not overflow the depth cast"
     );
 }
+
+/// The walker must not descend into a repository's `.git` directory. Nothing in there is a
+/// repository, and the guard that used to keep the `worktrees/<name>` metadata out of the
+/// results matched the hardcoded substring `/.git/worktrees/`, which cannot match on
+/// Windows, where the separator is a backslash.
+#[test]
+fn test_integration_unlimited_depth_ignores_git_internals() {
+    let temp_dir = TempDir::new().unwrap();
+
+    let main_repo_path = temp_dir.path().join("main-repo");
+    create_git_repo_with_commit(temp_dir.path(), "main-repo");
+
+    // `git worktree add` populates .git/worktrees/<name> with a HEAD, commondir, gitdir...
+    let worktree_path = temp_dir.path().join("feature-worktree");
+    let output = std::process::Command::new("git")
+        .args(["worktree", "add", "-b", "feature"])
+        .arg(&worktree_path)
+        .current_dir(&main_repo_path)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "failed to create worktree: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // An unlimited scan walks everything below the root, git directories included.
+    let args = Args {
+        dir: temp_dir.path().to_path_buf(),
+        depth: -1,
+        ..Default::default()
+    };
+    let (repos, failed) = args.find_repositories();
+
+    assert_eq!(failed, Vec::<String>::new());
+    assert_eq!(
+        repos.len(),
+        2,
+        "expected only the main repo and its worktree, got: {:?}",
+        repos.iter().map(|r| &r.repo_path).collect::<Vec<_>>()
+    );
+    for repo in &repos {
+        assert!(
+            !repo.path.components().any(|c| c.as_os_str() == ".git"),
+            "no result may point inside a git directory, got: {}",
+            repo.path.display()
+        );
+    }
+}

--- a/src/tests/integration_test.rs
+++ b/src/tests/integration_test.rs
@@ -171,6 +171,59 @@ fn test_integration_subdir_functionality() {
     assert_eq!(repos[0].name, "test-repo");
 }
 
+/// Repositories are collected in parallel with rayon, so the raw collection order depends
+/// on thread scheduling. `find_repositories` must hand back a sorted, reproducible order,
+/// otherwise consumers that do not sort themselves (`--json`, the failure warnings) emit a
+/// different order on every run.
+#[test]
+fn test_integration_find_repositories_returns_sorted_results() {
+    let temp_dir = TempDir::new().unwrap();
+
+    for name in ["delta", "alpha", "Charlie", "bravo"] {
+        create_git_repo_with_commit(temp_dir.path(), name);
+    }
+    // Directories with a `.git` that git cannot open end up in the failed list.
+    for name in ["zeta-broken", "echo-broken"] {
+        let broken = temp_dir.path().join(name);
+        fs::create_dir_all(&broken).unwrap();
+        fs::write(broken.join(".git"), "not a git directory").unwrap();
+    }
+
+    let args = Args {
+        dir: temp_dir.path().to_path_buf(),
+        depth: 1,
+        ..Default::default()
+    };
+
+    let (repos, failed) = args.find_repositories();
+
+    let paths: Vec<&str> = repos.iter().map(|r| r.repo_path.as_str()).collect();
+    assert_eq!(
+        paths,
+        ["alpha", "bravo", "Charlie", "delta"],
+        "repositories must be sorted case-insensitively"
+    );
+    assert_eq!(
+        failed,
+        ["echo-broken", "zeta-broken"],
+        "failed repositories must be sorted"
+    );
+
+    // The order must not depend on the parallel scheduling of a particular run.
+    for _ in 0..5 {
+        let (again, failed_again) = args.find_repositories();
+        assert_eq!(
+            again.iter().map(|r| &r.repo_path).collect::<Vec<_>>(),
+            repos.iter().map(|r| &r.repo_path).collect::<Vec<_>>(),
+            "repository order must be stable across scans"
+        );
+        assert_eq!(
+            failed_again, failed,
+            "failed repository order must be stable across scans"
+        );
+    }
+}
+
 #[test]
 fn test_integration_mixed_git_and_non_git_directories() {
     let temp_dir = TempDir::new().unwrap();

--- a/src/tests/integration_test.rs
+++ b/src/tests/integration_test.rs
@@ -317,14 +317,21 @@ fn test_integration_repository_fast_forward() {
         )
         .unwrap();
 
-    // Test that the clone was fast-forwarded
+    // Test that the clone was fast-forwarded, and that the reported state describes the
+    // repository *after* the merge rather than before it.
     let (repos, failed) = args.find_repositories();
 
     assert_eq!(repos.len(), 1);
     assert_eq!(failed.len(), 0);
-    assert_eq!(repos[0].commits, 1);
-    assert_eq!(repos[0].behind, 1);
     assert!(repos[0].fast_forwarded);
+    assert_eq!(
+        repos[0].commits, 2,
+        "commit count must be gathered after the fast-forward"
+    );
+    assert_eq!(
+        repos[0].behind, 0,
+        "a fast-forwarded repository is no longer behind its upstream"
+    );
 
     // Test that the clone is now up to date and doesn't need fast-forward
     let (repos, failed) = args.find_repositories();
@@ -334,6 +341,59 @@ fn test_integration_repository_fast_forward() {
     assert_eq!(repos[0].commits, 2);
     assert_eq!(repos[0].behind, 0);
     assert!(!repos[0].fast_forwarded);
+}
+
+/// A repository without any remote cannot be fetched from. It must still be reported
+/// instead of being swallowed into the list of failed repositories.
+#[test]
+fn test_integration_fetch_on_repo_without_remote_is_not_a_failure() {
+    let temp_dir = TempDir::new().unwrap();
+    let _repo = create_git_repo_with_commit(temp_dir.path(), "local-only");
+
+    let args = Args {
+        dir: temp_dir.path().to_path_buf(),
+        depth: 1,
+        fetch: true,
+        ..Default::default()
+    };
+
+    let (repos, failed) = args.find_repositories();
+
+    assert_eq!(
+        failed,
+        Vec::<String>::new(),
+        "repo must not be reported as failed"
+    );
+    assert_eq!(repos.len(), 1, "repo must still be listed");
+    assert_eq!(repos[0].name, "local-only");
+    assert!(!repos[0].fast_forwarded);
+}
+
+/// A branch without an upstream cannot be fast-forwarded. `--ff` must degrade to "no
+/// fast-forward happened" rather than dropping the repository from the output.
+#[test]
+fn test_integration_fast_forward_without_upstream_is_not_a_failure() {
+    let temp_dir = TempDir::new().unwrap();
+    let _repo = create_git_repo_with_commit(temp_dir.path(), "no-upstream");
+
+    let args = Args {
+        dir: temp_dir.path().to_path_buf(),
+        depth: 1,
+        fetch: true,
+        fast_forward: true,
+        ..Default::default()
+    };
+
+    let (repos, failed) = args.find_repositories();
+
+    assert_eq!(
+        failed,
+        Vec::<String>::new(),
+        "repo must not be reported as failed"
+    );
+    assert_eq!(repos.len(), 1, "repo must still be listed");
+    assert!(!repos[0].fast_forwarded);
+    assert!(repos[0].is_local_only);
 }
 
 #[test]

--- a/src/tests/integration_test.rs
+++ b/src/tests/integration_test.rs
@@ -770,3 +770,108 @@ fn test_integration_unlimited_depth_ignores_git_internals() {
         );
     }
 }
+
+/// The `--subdir` flag exists for layouts where the checkout lives one level below the
+/// project directory (`repo-name/checkout`). The repository must be picked up through the
+/// subdirectory, at a depth where it would not be found otherwise.
+#[test]
+fn test_integration_subdir_finds_repo_below_the_scanned_level() {
+    let temp_dir = TempDir::new().unwrap();
+
+    // temp/project/checkout/.git - `project` itself is not a repository.
+    let project_dir = temp_dir.path().join("project");
+    fs::create_dir_all(&project_dir).unwrap();
+    create_git_repo_with_commit(&project_dir, "checkout");
+
+    // Depth 1 only reaches `project`, so without --subdir there is nothing to find.
+    let without_subdir = Args {
+        dir: temp_dir.path().to_path_buf(),
+        depth: 1,
+        ..Default::default()
+    };
+    let (repos, failed) = without_subdir.find_repositories();
+    assert_eq!(
+        repos.len(),
+        0,
+        "the checkout is a level below the scan depth"
+    );
+    assert_eq!(failed.len(), 0);
+
+    // With --subdir, `project/checkout` is inspected and found.
+    let with_subdir = Args {
+        dir: temp_dir.path().to_path_buf(),
+        depth: 1,
+        subdir: Some("checkout".to_owned()),
+        ..Default::default()
+    };
+    let (repos, failed) = with_subdir.find_repositories();
+    assert_eq!(failed.len(), 0);
+    assert_eq!(repos.len(), 1, "--subdir must find the nested checkout");
+    assert_eq!(repos[0].repo_path, "project/checkout");
+
+    // A subdir that does not exist anywhere must simply yield nothing.
+    let missing_subdir = Args {
+        dir: temp_dir.path().to_path_buf(),
+        depth: 1,
+        subdir: Some("does-not-exist".to_owned()),
+        ..Default::default()
+    };
+    let (repos, failed) = missing_subdir.find_repositories();
+    assert_eq!(repos.len(), 0);
+    assert_eq!(failed.len(), 0);
+}
+
+/// A clone that is in sync with its remote is Clean; committing locally without pushing
+/// turns it into Unpushed and marks it as having unpushed work.
+#[test]
+fn test_integration_clean_and_unpushed_against_a_remote() {
+    let remote_dir = TempDir::new().unwrap();
+    let local_dir = TempDir::new().unwrap();
+
+    let remote_path = remote_dir.path().join("origin-repo");
+    create_git_repo_with_commit(remote_dir.path(), "origin-repo");
+
+    let clone_path = local_dir.path().join("clone");
+    let clone = Repository::clone(&remote_path.to_string_lossy(), &clone_path).unwrap();
+    let mut config = clone.config().unwrap();
+    config.set_str("user.name", "Test User").unwrap();
+    config.set_str("user.email", "test@example.com").unwrap();
+    drop(config);
+
+    let args = Args {
+        dir: local_dir.path().to_path_buf(),
+        depth: 1,
+        ..Default::default()
+    };
+
+    // A fresh clone tracks its remote and matches it exactly.
+    let (repos, _) = args.find_repositories();
+    assert_eq!(repos.len(), 1);
+    assert_eq!(repos[0].status, crate::gitinfo::status::Status::Clean);
+    assert!(!repos[0].has_unpushed);
+    assert!(!repos[0].is_local_only, "a clone has an upstream");
+    assert_eq!(repos[0].ahead, 0);
+
+    // Commit locally without pushing.
+    fs::write(clone_path.join("local.txt"), "local work").unwrap();
+    let mut index = clone.index().unwrap();
+    index.add_path(Path::new("local.txt")).unwrap();
+    index.write().unwrap();
+    let tree = clone.find_tree(index.write_tree().unwrap()).unwrap();
+    let sig = clone.signature().unwrap();
+    let parent = clone.head().unwrap().peel_to_commit().unwrap();
+    clone
+        .commit(Some("HEAD"), &sig, &sig, "local commit", &tree, &[&parent])
+        .unwrap();
+
+    let (repos, _) = args.find_repositories();
+    assert_eq!(repos.len(), 1);
+    assert_eq!(
+        repos[0].status,
+        crate::gitinfo::status::Status::Unpushed,
+        "a committed but unpushed change must be reported as Unpushed"
+    );
+    assert!(repos[0].has_unpushed);
+    assert_eq!(repos[0].ahead, 1);
+    assert_eq!(repos[0].behind, 0);
+}

--- a/src/tests/integration_test.rs
+++ b/src/tests/integration_test.rs
@@ -676,3 +676,48 @@ fn test_integration_scanning_a_repository_directly_shows_its_name() {
         repo_dir.canonicalize().unwrap()
     );
 }
+
+/// `-1` is the documented spelling of "no limit", but the guard let *any* negative value
+/// through to the same unlimited branch. Rather than have `--depth -5` mean something
+/// different from what the help text says, every negative depth is unlimited, and a depth
+/// of 0 (which would otherwise find nothing) behaves like 1.
+#[test]
+fn test_integration_depth_edge_values() {
+    let temp_dir = TempDir::new().unwrap();
+
+    let level1 = temp_dir.path().join("level1");
+    let level2 = level1.join("level2");
+    fs::create_dir_all(&level2).unwrap();
+
+    create_git_repo_with_commit(temp_dir.path(), "root-repo");
+    create_git_repo_with_commit(&level1, "level1-repo");
+    create_git_repo_with_commit(&level2, "level2-repo");
+
+    let scan = |depth: i32| {
+        let args = Args {
+            dir: temp_dir.path().to_path_buf(),
+            depth,
+            ..Default::default()
+        };
+        let (repos, _) = args.find_repositories();
+        repos.len()
+    };
+
+    // Depth 0 finds nothing without the clamp; it must behave like depth 1.
+    assert_eq!(scan(0), 1, "depth 0 must behave like depth 1");
+    assert_eq!(scan(1), 1);
+    assert_eq!(scan(3), 3);
+
+    // Every negative depth is unlimited, not just -1.
+    assert_eq!(scan(-1), 3, "-1 must scan all subdirectories");
+    assert_eq!(
+        scan(-5),
+        3,
+        "any negative depth must scan all subdirectories"
+    );
+    assert_eq!(
+        scan(i32::MIN),
+        3,
+        "i32::MIN must not overflow the depth cast"
+    );
+}

--- a/src/tests/main_test.rs
+++ b/src/tests/main_test.rs
@@ -1,10 +1,15 @@
-use std::path::PathBuf;
+use std::{fs, io, path::Path, path::PathBuf};
 
 use clap::Parser;
+use clap_complete::Shell;
+use git2::Repository;
+use tempfile::TempDir;
 
 use crate::{
     cli::Args,
+    completions,
     gitinfo::{repoinfo::RepoInfo, status::Status},
+    run,
 };
 
 fn repo_info_with_status(status: Status, stash_count: usize, fast_forwarded: bool) -> RepoInfo {
@@ -72,4 +77,176 @@ fn test_args_parse_json_fast_forward_and_subdir() {
     assert!(args.fast_forward);
     assert_eq!(args.subdir.as_deref(), Some("checkout"));
     assert_eq!(args.depth, -1);
+}
+
+/// Creates a repository with one commit, and optionally an uncommitted file.
+fn create_repo(parent: &Path, name: &str, dirty: bool) {
+    let repo_path = parent.join(name);
+    fs::create_dir_all(&repo_path).unwrap();
+    let repo = Repository::init(&repo_path).unwrap();
+
+    let mut config = repo.config().unwrap();
+    config.set_str("user.name", "Test User").unwrap();
+    config.set_str("user.email", "test@example.com").unwrap();
+    drop(config);
+
+    fs::write(repo_path.join("README.md"), "# Test\n").unwrap();
+    let mut index = repo.index().unwrap();
+    index.add_path(Path::new("README.md")).unwrap();
+    index.write().unwrap();
+    let tree_id = index.write_tree().unwrap();
+    let tree = repo.find_tree(tree_id).unwrap();
+    let sig = repo.signature().unwrap();
+    repo.commit(Some("HEAD"), &sig, &sig, "Initial commit", &tree, &[])
+        .unwrap();
+
+    if dirty {
+        fs::write(repo_path.join("uncommitted.txt"), "work in progress").unwrap();
+    }
+}
+
+/// A scan directory holding one clean and one dirty repository.
+fn scan_dir() -> TempDir {
+    let temp = TempDir::new().unwrap();
+    create_repo(temp.path(), "clean-repo", false);
+    create_repo(temp.path(), "dirty-repo", true);
+    temp
+}
+
+#[test]
+fn test_run_prints_table() {
+    let temp = scan_dir();
+    let args = Args {
+        dir: temp.path().to_path_buf(),
+        depth: 1,
+        ..Default::default()
+    };
+    run(&args, &mut io::sink());
+}
+
+#[test]
+fn test_run_with_all_display_options() {
+    let temp = scan_dir();
+    let args = Args {
+        dir: temp.path().to_path_buf(),
+        depth: 1,
+        remote: true,
+        path: true,
+        condensed: true,
+        summary: true,
+        ..Default::default()
+    };
+    run(&args, &mut io::sink());
+}
+
+#[test]
+fn test_run_with_non_clean_filter() {
+    let temp = scan_dir();
+    let args = Args {
+        dir: temp.path().to_path_buf(),
+        depth: 1,
+        non_clean: true,
+        summary: true,
+        ..Default::default()
+    };
+    run(&args, &mut io::sink());
+}
+
+#[test]
+fn test_run_json() {
+    let temp = scan_dir();
+    let args = Args {
+        dir: temp.path().to_path_buf(),
+        depth: 1,
+        json: true,
+        ..Default::default()
+    };
+    run(&args, &mut io::sink());
+}
+
+#[test]
+fn test_run_on_directory_without_repositories() {
+    let temp = TempDir::new().unwrap();
+    let args = Args {
+        dir: temp.path().to_path_buf(),
+        depth: 1,
+        summary: true,
+        ..Default::default()
+    };
+    run(&args, &mut io::sink());
+}
+
+/// A directory whose `.git` git cannot open is reported as failed, not as a hard error.
+#[test]
+fn test_run_reports_failed_repositories() {
+    let temp = TempDir::new().unwrap();
+    let broken = temp.path().join("broken-repo");
+    fs::create_dir_all(&broken).unwrap();
+    fs::write(broken.join(".git"), "not a git directory").unwrap();
+
+    let args = Args {
+        dir: temp.path().to_path_buf(),
+        depth: 1,
+        summary: true,
+        ..Default::default()
+    };
+    run(&args, &mut io::sink());
+}
+
+#[test]
+fn test_run_legend() {
+    for condensed in [false, true] {
+        let args = Args {
+            legend: true,
+            condensed,
+            ..Default::default()
+        };
+        run(&args, &mut io::sink());
+    }
+}
+
+/// `--completions` must short-circuit before anything is scanned or printed, so that it
+/// stays usable from a shell's startup files no matter which directory it runs in.
+#[test]
+fn test_run_completions_short_circuits_the_scan() {
+    let args = Args {
+        dir: PathBuf::from("/nonexistent/directory/that/does/not/exist"),
+        depth: -1,
+        completions: Some(Shell::Bash),
+        // Would both be honoured if the scan were reached.
+        legend: true,
+        json: true,
+        ..Default::default()
+    };
+
+    let mut out = Vec::new();
+    run(&args, &mut out);
+
+    let script = String::from_utf8(out).unwrap();
+    assert!(
+        script.contains("git-statuses"),
+        "completion script must mention the binary name"
+    );
+    assert!(
+        !script.contains("Cherry Pick"),
+        "the legend must not be printed when generating completions"
+    );
+}
+
+#[test]
+fn test_completions_for_every_supported_shell() {
+    for shell in [
+        Shell::Bash,
+        Shell::Zsh,
+        Shell::Fish,
+        Shell::PowerShell,
+        Shell::Elvish,
+    ] {
+        let mut out = Vec::new();
+        completions(shell, &mut out);
+        assert!(
+            !out.is_empty(),
+            "completion script for {shell} must not be empty"
+        );
+    }
 }

--- a/src/tests/printer_test.rs
+++ b/src/tests/printer_test.rs
@@ -7,19 +7,19 @@ use crate::printer::{failed_summary, json_output, legend, repositories_table, su
 
 #[test]
 fn test_repositories_table_empty() {
-    let mut repos: Vec<RepoInfo> = Vec::new();
+    let repos: Vec<RepoInfo> = Vec::new();
     let args = Args {
         dir: ".".into(),
         depth: 1,
         ..Default::default()
     };
-    repositories_table(&mut repos, &args);
+    repositories_table(&repos, &args);
     // Assert that no panic occurs and no output is generated
 }
 
 #[test]
 fn test_repositories_table_with_data() {
-    let mut repos = vec![RepoInfo {
+    let repos = vec![RepoInfo {
         name: "repo1".to_owned(),
         branch: "main".to_owned(),
         ahead: 1,
@@ -41,7 +41,7 @@ fn test_repositories_table_with_data() {
         remote: true,
         ..Default::default()
     };
-    repositories_table(&mut repos, &args);
+    repositories_table(&repos, &args);
     // Assert that the table is printed correctly
 }
 
@@ -53,7 +53,7 @@ fn test_print_legend() {
 
 #[test]
 fn test_repositories_table_with_stashes_and_local_only() {
-    let mut repos = vec![
+    let repos = vec![
         RepoInfo {
             name: "repo-with-stash".to_owned(),
             branch: "main".to_owned(),
@@ -92,13 +92,13 @@ fn test_repositories_table_with_stashes_and_local_only() {
         depth: 1,
         ..Default::default()
     };
-    repositories_table(&mut repos, &args);
+    repositories_table(&repos, &args);
     // Assert that stash info and local-only status are displayed correctly
 }
 
 #[test]
 fn test_repositories_table_with_path_option() {
-    let mut repos = vec![RepoInfo {
+    let repos = vec![RepoInfo {
         name: "test-repo".to_owned(),
         branch: "main".to_owned(),
         ahead: 0,
@@ -120,13 +120,13 @@ fn test_repositories_table_with_path_option() {
         path: true,
         ..Default::default()
     };
-    repositories_table(&mut repos, &args);
+    repositories_table(&repos, &args);
     // Should include path column
 }
 
 #[test]
 fn test_repositories_table_condensed_layout() {
-    let mut repos = vec![RepoInfo {
+    let repos = vec![RepoInfo {
         name: "repo".to_owned(),
         branch: "develop".to_owned(),
         ahead: 2,
@@ -150,13 +150,13 @@ fn test_repositories_table_condensed_layout() {
         path: true,
         ..Default::default()
     };
-    repositories_table(&mut repos, &args);
+    repositories_table(&repos, &args);
     // Should use condensed table format
 }
 
 #[test]
 fn test_repositories_table_non_clean_filter() {
-    let mut repos = vec![
+    let repos = vec![
         RepoInfo {
             name: "clean-repo".to_owned(),
             branch: "main".to_owned(),
@@ -196,13 +196,15 @@ fn test_repositories_table_non_clean_filter() {
         non_clean: true,
         ..Default::default()
     };
-    repositories_table(&mut repos, &args);
+    repositories_table(&repos, &args);
     // Should only display dirty repo
 }
 
+/// Sorting is the responsibility of `Args::find_repositories`, which hands the printer an
+/// already ordered slice. The printer must render the rows in exactly that order.
 #[test]
-fn test_repositories_table_sorting() {
-    let mut repos = vec![
+fn test_repositories_table_renders_rows_in_given_order() {
+    let repos = vec![
         RepoInfo {
             name: "zebra-repo".to_owned(),
             branch: "main".to_owned(),
@@ -257,16 +259,16 @@ fn test_repositories_table_sorting() {
         depth: 1,
         ..Default::default()
     };
-    repositories_table(&mut repos, &args);
-    // Should be sorted alphabetically (case-insensitive)
-    assert_eq!(repos[0].name, "Alpha-Repo");
-    assert_eq!(repos[1].name, "beta-repo");
-    assert_eq!(repos[2].name, "zebra-repo");
+    repositories_table(&repos, &args);
+    // The printer must not reorder what it was given.
+    assert_eq!(repos[0].name, "zebra-repo");
+    assert_eq!(repos[1].name, "Alpha-Repo");
+    assert_eq!(repos[2].name, "beta-repo");
 }
 
 #[test]
 fn test_repositories_table_various_statuses() {
-    let mut repos = vec![
+    let repos = vec![
         RepoInfo {
             name: "rebase-repo".to_owned(),
             branch: "feature".to_owned(),
@@ -321,7 +323,7 @@ fn test_repositories_table_various_statuses() {
         depth: 1,
         ..Default::default()
     };
-    repositories_table(&mut repos, &args);
+    repositories_table(&repos, &args);
     // Should display all different status types with appropriate colors
 }
 
@@ -445,7 +447,7 @@ fn test_summary_edge_cases() {
 
 #[test]
 fn test_repositories_table_marks_worktree_rows() {
-    let mut repos = vec![RepoInfo {
+    let repos = vec![RepoInfo {
         name: "worktree-repo".to_owned(),
         branch: "feature".to_owned(),
         ahead: 0,
@@ -466,7 +468,7 @@ fn test_repositories_table_marks_worktree_rows() {
         depth: 1,
         ..Default::default()
     };
-    repositories_table(&mut repos, &args);
+    repositories_table(&repos, &args);
 }
 
 #[test]

--- a/src/tests/printer_test.rs
+++ b/src/tests/printer_test.rs
@@ -3,7 +3,9 @@ use std::path::PathBuf;
 use crate::cli::Args;
 use crate::gitinfo::repoinfo::RepoInfo;
 use crate::gitinfo::status::Status;
-use crate::printer::{failed_summary, json_output, legend, repositories_table, summary};
+use crate::printer::{
+    failed_summary, json_output, json_value, legend, repositories_table, summary,
+};
 
 #[test]
 fn test_repositories_table_empty() {
@@ -196,8 +198,10 @@ fn test_repositories_table_non_clean_filter() {
         non_clean: true,
         ..Default::default()
     };
-    repositories_table(&repos, &args);
-    // Should only display dirty repo
+    let displayed = args.filter_repos(&repos);
+    assert_eq!(displayed.len(), 1);
+    assert_eq!(displayed[0].name, "dirty-repo");
+    repositories_table(&displayed, &args);
 }
 
 /// Sorting is the responsibility of `Args::find_repositories`, which hands the printer an
@@ -491,4 +495,108 @@ fn test_json_output_smoke() {
     }];
     let failed = vec!["broken-repo".to_owned()];
     json_output(&repos, &failed);
+
+    let value = json_value(&repos, &failed);
+    assert_eq!(value["repositories"][0]["name"], "json-repo");
+    assert_eq!(value["failed"][0], "broken-repo");
+}
+
+fn repo_named(name: &str, status: Status) -> RepoInfo {
+    RepoInfo {
+        name: name.to_owned(),
+        branch: "main".to_owned(),
+        ahead: 0,
+        behind: 0,
+        commits: 1,
+        status,
+        has_unpushed: false,
+        remote_url: None,
+        path: PathBuf::from("/path/to").join(name),
+        stash_count: 0,
+        is_local_only: false,
+        fast_forwarded: false,
+        repo_path: name.to_owned(),
+        is_worktree: false,
+    }
+}
+
+/// `--non-clean` used to be applied by the table printer only, so `--json --non-clean`
+/// still emitted every clean repository. Both output formats must show the same selection.
+#[test]
+fn test_non_clean_filter_applies_to_json_output() {
+    let repos = vec![
+        repo_named("clean-repo", Status::Clean),
+        repo_named("dirty-repo", Status::Dirty(2)),
+        repo_named("unpushed-repo", Status::Unpushed),
+    ];
+    let args = Args {
+        dir: ".".into(),
+        depth: 1,
+        non_clean: true,
+        json: true,
+        ..Default::default()
+    };
+
+    let displayed = args.filter_repos(&repos);
+    let names: Vec<&str> = displayed.iter().map(|r| r.name.as_str()).collect();
+    assert_eq!(
+        names,
+        ["dirty-repo", "unpushed-repo"],
+        "clean repositories must be filtered out"
+    );
+
+    let value = json_value(&displayed, &[]);
+    let json_names: Vec<&str> = value["repositories"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| r["name"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        json_names,
+        ["dirty-repo", "unpushed-repo"],
+        "JSON output must honour --non-clean"
+    );
+}
+
+/// Without `--non-clean` the filter must be a no-op and must not clone the input.
+#[test]
+fn test_filter_repos_without_non_clean_borrows_everything() {
+    let repos = vec![
+        repo_named("clean-repo", Status::Clean),
+        repo_named("dirty-repo", Status::Dirty(1)),
+    ];
+    let args = Args {
+        dir: ".".into(),
+        depth: 1,
+        ..Default::default()
+    };
+
+    let displayed = args.filter_repos(&repos);
+    assert!(
+        matches!(displayed, std::borrow::Cow::Borrowed(_)),
+        "the unfiltered path must not copy the scan result"
+    );
+    assert_eq!(displayed.len(), 2);
+}
+
+/// When `--non-clean` filters everything away, the printer must say so instead of drawing
+/// a table with a header and no rows.
+#[test]
+fn test_non_clean_filter_removing_everything_prints_no_repositories() {
+    let repos = vec![
+        repo_named("clean-a", Status::Clean),
+        repo_named("clean-b", Status::Clean),
+    ];
+    let args = Args {
+        dir: ".".into(),
+        depth: 1,
+        non_clean: true,
+        ..Default::default()
+    };
+
+    let displayed = args.filter_repos(&repos);
+    assert!(displayed.is_empty());
+    // Hits the "No repositories found." branch rather than rendering an empty table.
+    repositories_table(&displayed, &args);
 }

--- a/src/tests/snapshots/git_statuses__tests__cli_test__git-statuses.snap
+++ b/src/tests/snapshots/git_statuses__tests__cli_test__git-statuses.snap
@@ -14,7 +14,7 @@ Arguments:
 
 Options:
   -d, --depth <DEPTH>
-          Recursively scan all subdirectories to the given depth. If set to 1, only the current directory is scanned. If set to -1, all subdirectories are scanned. (this may take a while)
+          Recursively scan all subdirectories to the given depth. If set to 1, only the current directory is scanned. If set to a negative value, all subdirectories are scanned. (this may take a while)
           
           [default: 1]
 

--- a/src/tests/util_test.rs
+++ b/src/tests/util_test.rs
@@ -50,8 +50,8 @@ fn test_print_repositories_and_summary() {
         summary: true,
         ..Default::default()
     };
-    let mut repos = vec![repo];
-    printer::repositories_table(&mut repos, &args);
+    let repos = vec![repo];
+    printer::repositories_table(&repos, &args);
     printer::summary(&repos, 0);
 }
 
@@ -94,8 +94,8 @@ fn test_print_repositories_with_remote() {
         remote: true,
         ..Default::default()
     };
-    let mut repos = vec![repo];
-    printer::repositories_table(&mut repos, &args);
+    let repos = vec![repo];
+    printer::repositories_table(&repos, &args);
 }
 
 // New tests for GitPathExt trait


### PR DESCRIPTION
Fixes a set of bugs found while auditing the repo. Each is a separate commit with a regression test that fails without the fix.

### Repositories silently disappearing or showing stale numbers

`--fetch` on a repository without a remote made `fetch_origin` return an error, which propagated and got the repository filed as *failed* — so it vanished from the output entirely. The same happened with `--ff` on a branch without an upstream.

Separately, `merge_ff` ran *after* ahead/behind, commit count and status were gathered, so a fast-forwarded repository was displayed with its pre-merge numbers: still "behind 1" while simultaneously marked as fast-forwarded. Fetch and merge now happen before any state is read, and both are best-effort with a warning.

`fetch_origin` also ran git in `repo.path().parent()`, which for a worktree is `<main>/.git/worktrees`, not a working directory.

### A typechanged file was reported as Clean

Whether a repository is dirty and how many files changed were two separately maintained lists of git status bits, and neither included `TYPECHANGE`. Replacing a tracked file with a symlink — which `git status` reports as ` T` — left the repository reported as Clean with zero changes. Both checks now share a single `CHANGED` bitmask.

### `--json` ignored `--non-clean`

The filter lived inside the table printer, so `--json --non-clean` emitted every clean repository — useless for the exact scripting case JSON exists for. It now lives in `Args::filter_repos` and is applied once, so the formats cannot disagree. Filtering everything away now correctly reports "No repositories found." instead of printing a table header with no rows.

### Non-deterministic output order

Repositories are collected in parallel via rayon and only the table sorted afterwards, so `--json` and the failure warnings emitted a different order on every run over the same directory.

### Remote URL name parsing

`git@host:repo.git` (no slash in the path) became the whole `git@host:repo` string; a trailing slash produced an empty name; and `trim_end_matches(".git")` strips *every* trailing occurrence, so a repository genuinely named `repo.git` was displayed as `repo`.

### Directory column for the scan root

Running git-statuses from inside a checkout — the no-argument default — left the relative path empty and fell back to the absolute path, so the column read `/home/user/code/my-repo` for a repository that would be listed as plain `my-repo` had the parent been scanned.

### Depth guard and Windows path matching

The depth guard read `depth != -1 && depth >= 0`, in which the first half is dead. Any negative value already meant "unlimited", which is now what the help text says. Worktree metadata was excluded by matching the literal substring `/.git/worktrees/`, which cannot match on Windows; the `.git` directory is now pruned from the walk by file name.

### Coverage

Coverage was **89.95%**, below the 90% threshold the tarpaulin job already enforces — **the gate was failing on main**. Most of the gap was `src/main.rs` at 0/19 lines, since everything lived in `main()`, which no test can call. It is now split into a testable `run(args, out)`.

Coverage is now **96.55%** (`printer.rs`, `status.rs`, `repoinfo.rs`, `util.rs` at 100%) and the gate moves to 95%.

---

Two things in the diff worth flagging for review:

- **An existing test's assertions changed.** `test_integration_repository_fast_forward` asserted `commits == 1, behind == 1` on a repo it had just fast-forwarded — it had pinned the stale-stats bug in place.
- **`test_integration_subdir_functionality` never exercised `--subdir`.** Its repository sat at a depth where the ordinary scan already found it. It is left in place and a real one added alongside.